### PR TITLE
Make all Acceleration Events in context of Change of Control

### DIFF
--- a/purchase-agreement.cform.m4
+++ b/purchase-agreement.cform.m4
@@ -38,11 +38,11 @@ This Common Stock Purchase Agreement (this ""Agreement"") is made as of [Effecti
 
             \ Acceleration \
 
-                \\ ""Acceleration Event"" means any of:
+                \\ ""Acceleration Event"" means any of the following that happens in connection with or following a <Change of Control>:
 
                     \\ <Purchaser>'s <Continuous Service Status> terminates, other than as a result of <Purchaser>'s death or <Disability>, and the <Company> determines in good faith that there was no <Good Reason to Terminate>.
 
-                    \\ In connection with or following a <Change of Control>:
+                    \\ <Purchaser> resigns as follows:
                         \\ <Purchaser> gives written notice to the <Company> of a <Good Reason to Resign> within 60 calendar days of when it happens (""Resignation Notice""),
                         \\ the <Company> does not act to remove the <Good Reason to Resign> within 30 calendar days of receiving <Resignation Notice>,
                         \\ <Purchaser> resigns effective no later than 60 calendar days after giving <Resignation Notice>, and


### PR DESCRIPTION
This PR changes the definition of "Acceleration Event" to cover only firings that occur in connection with or after changes of control.

I am now confident this is what the Orrick form intends, based on a somewhat novel read of the published form document. @jboehmig, I'm not sure what Cai's GitHub handle is, but I'd recommend you @-mention him. This is right on point of a discussion we've had.

This is the Orrick language for double-trigger acceleration, which is entirely wrapped in [brackets] denoting an alternative to the single-trigger language also provided: 

> Notwithstanding the foregoing, if Purchaser is terminated without Cause (as defined below) by the Company (or a successor, if appropriate) [or resigns for Good Reason (as defined below)] in connection with or following the consummation of a Change of Control (as defined below), then the vesting of the Unvested Shares shall accelerate such that the Repurchase Option in Section 3(a) shall lapse as to ____% of the Unvested Shares.

Note the additional brackets around "or resigns for Good Reason".

If you simply remove all the brackets, you end up with a classic syntactic ambiguity:

> ... if Purchaser is terminated without Cause (as defined below) by the Company (or a successor, if appropriate) or resigns for Good Reason (as defined below) in connection with or following the consummation of a Change of Control (as defined below) ...

Does termination without Cause count if it's not "in connection with or following ... Change of Control"? Ken Adams' Manual of Style for Contract Drafting calls this kind of construct a "trailing modifier".

However, if you take the double-trigger provision but omit "or resigns ...", it's clear the trailing modifier applies to terminations:

> ... if Purchaser is terminated without Cause (as defined below) by the Company (or a successor, if appropriate) in connection with or following the consummation of a Change of Control (as defined below) ...

Long story short, I believe that I faithfully tracked what the Orrick form says if you opt into all the provided optional language for double-trigger acceleration. However, if you step back and look at the clumsy template-like brackets in the published .docx, you come to a different conclusion about the intent of the form. 

If a court managed to come to the same conclusion, it would have to do so without the benefit of bracket-leaden form. It couldn't perform this counterfactual analysis to reach certainty. At least, it couldn't do so overtly.

Come to think of it, I would strongly recommend that Cai at least skims Chapters 11 and 12 of MSCD (about 40 page total). I think that's essential reading for anyone looking at the contract-template problem, especially if you're primed---as all programmers are---to take mental refuge in the familiarity of the more generic string templating problem. Adams' very structured approach is probably the best inoculation against these kinds of substantive issues.
